### PR TITLE
Enhance semantic HTML

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled'
 import Menu from '../../menu/containers/Menu'
 import MarkdownEditor from '../../editor/containers/MarkdownEditor'
 
-const AppContainer = styled.div({
+const AppContainer = styled.main({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'flex-start',
@@ -27,7 +27,7 @@ const LayoutContainer = styled.div(({ theme }) => ({
   },
 }))
 
-const MenuContainer = styled.div(({ theme }) => ({
+const MenuContainer = styled.nav(({ theme }) => ({
   position: 'absolute',
   top: 0,
   left: 0,
@@ -47,7 +47,7 @@ export const App: React.FC = () => (
   <AppContainer>
     <LayoutContainer>
       <MarkdownEditor />
-      <MenuContainer>
+      <MenuContainer aria-label="Main menu">
         <Menu />
       </MenuContainer>
     </LayoutContainer>

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -50,6 +50,10 @@ export const interactiveStyles = ({ theme }: { theme: Theme }) =>
         opacity: theme.interactions.activeOpacity,
       },
     },
+    '&:focus-visible': {
+      outline: `2px solid ${theme.colors.primary}`,
+      outlineOffset: '2px',
+    },
   })
 
 const StyledInteractive = styled.button(interactiveStyles)
@@ -90,7 +94,9 @@ export const Button: React.FC<Props> = ({
   const interactiveProps = href
     ? {
         as: 'a' as const,
-        href,
+        href: disabled ? undefined : href,
+        tabIndex: disabled ? -1 : undefined,
+        'aria-disabled': disabled ? true : undefined,
         target: externalLink ? '_blank' : undefined,
         rel: externalLink ? 'noreferrer' : undefined,
       }

--- a/src/app/components/Button.tsx
+++ b/src/app/components/Button.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import styled from '@emotion/styled'
 import { css, Theme } from '@emotion/react'
 
+import { focusVisibleStyles } from '../../shared/styles'
+
 import { Appear } from './Appear'
 
 interface Props {
@@ -50,13 +52,9 @@ export const interactiveStyles = ({ theme }: { theme: Theme }) =>
         opacity: theme.interactions.activeOpacity,
       },
     },
-    '&:focus-visible': {
-      outline: `2px solid ${theme.colors.primary}`,
-      outlineOffset: '2px',
-    },
   })
 
-const StyledInteractive = styled.button(interactiveStyles)
+const StyledInteractive = styled.button(interactiveStyles, focusVisibleStyles)
 
 export const interactiveLabelStyles = ({
   theme,

--- a/src/app/components/Switch.tsx
+++ b/src/app/components/Switch.tsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import styled from '@emotion/styled'
+
+import { focusWithinStyles } from '../../shared/styles'
+
 import { Appear } from './Appear'
 import { InteractiveLabel } from './InteractiveLabel'
 
@@ -10,13 +13,16 @@ interface Props {
   size: number
 }
 
-const SwitchContainer = styled.label(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  cursor: 'pointer',
-  gap: theme.spacing(1),
-  userSelect: 'none',
-}))
+const SwitchContainer = styled.label(
+  ({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+    gap: theme.spacing(1),
+    userSelect: 'none',
+  }),
+  focusWithinStyles,
+)
 
 const SwitchWrapper = styled.div({
   position: 'relative',

--- a/src/app/components/Tooltip.tsx
+++ b/src/app/components/Tooltip.tsx
@@ -16,12 +16,18 @@ import {
   FloatingArrow,
 } from '@floating-ui/react'
 import { useTheme } from '@emotion/react'
+
 import { Label } from './Label'
 
 interface Props {
   label: string
   children: React.ReactNode
 }
+
+const StyledElementContainer = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+})
 
 const TooltipContainer = styled.div(({ theme }) => ({
   backgroundColor: theme.colors.modal,
@@ -49,7 +55,7 @@ const Tooltip: React.FC<Props> = ({ label, children }) => {
     // Make sure the tooltip stays on the screen
     whileElementsMounted: autoUpdate,
     middleware: [
-      offset(12),
+      offset(16),
       flip(),
       shift(),
       arrow({
@@ -76,16 +82,9 @@ const Tooltip: React.FC<Props> = ({ label, children }) => {
 
   return (
     <>
-      <div
-        css={{
-          display: 'flex',
-          alignItems: 'center',
-        }}
-        ref={refs.setReference}
-        {...getReferenceProps()}
-      >
+      <StyledElementContainer ref={refs.setReference} {...getReferenceProps()}>
         {children}
-      </div>
+      </StyledElementContainer>
       <FloatingPortal id="floating-portal">
         {isOpen && (
           <div

--- a/src/editor/components/MarkdownEditor.tsx
+++ b/src/editor/components/MarkdownEditor.tsx
@@ -44,6 +44,17 @@ const CodeEditor = styled(Editor)(({ theme }) => ({
   [theme.breakpoints.toolbar]: {
     width: theme.layout.pageWidth,
     minHeight: theme.layout.pageHeight,
+    outline: `2px solid transparent`,
+    boxShadow:
+      theme.mode === 'dark'
+        ? `none`
+        : `0 0 ${theme.spacing(1)} 0 ${theme.colors.paper}`,
+    borderRadius: theme.spacing(0.5),
+    '&:focus-within': {
+      outline: `2px solid ${theme.colors.editorFocus}`,
+      boxShadow: `0 0 ${theme.spacing(1)} 0 ${theme.colors.paper}`,
+      transition: `outline ${theme.animations.interaction}, box-shadow ${theme.animations.interaction}`,
+    },
   },
   '@media print': {
     width: 'auto',

--- a/src/editor/components/MarkdownEditor.tsx
+++ b/src/editor/components/MarkdownEditor.tsx
@@ -121,7 +121,11 @@ const MarkdownEditor: React.FC<Props> = ({ content, onContentChange }) => {
         <style>{editorLightTheme}</style>
       )}
       <EditorContainer className="editor-container" ref={containerRef}>
+        <label htmlFor="markdown-editor-input" className="sr-only">
+          Markdown editor
+        </label>
         <CodeEditor
+          textareaId="markdown-editor-input"
           className="code-editor"
           value={content}
           onValueChange={onContentChange}

--- a/src/menu/components/MenuButton.tsx
+++ b/src/menu/components/MenuButton.tsx
@@ -1,22 +1,27 @@
 import React from 'react'
 import styled from '@emotion/styled'
 
+import { focusVisibleStyles } from '../../shared/styles'
+
 interface Props {
   isOpen: boolean
   onClick: () => void
   size: number
 }
 
-const MenuButtonContainer = styled.button<{ size: number }>(({ size }) => ({
-  width: size,
-  height: size,
-  padding: 0,
-  margin: 0,
-  background: 'transparent',
-  border: 'none',
-  cursor: 'pointer',
-  position: 'relative',
-}))
+const MenuButtonContainer = styled.button<{ size: number }>(
+  ({ size }) => ({
+    width: size,
+    height: size,
+    padding: 0,
+    margin: 0,
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    position: 'relative',
+  }),
+  focusVisibleStyles,
+)
 
 const MenuButtonLineTemplate = styled.div<{ isOpen: boolean }>(({ theme }) => ({
   width: '100%',

--- a/src/menu/components/Toolbar.tsx
+++ b/src/menu/components/Toolbar.tsx
@@ -31,6 +31,17 @@ const ToolbarItemContainer = styled.div(({ theme }) => ({
   gap: theme.spacing(1),
 }))
 
+const StatsList = styled.ul(({ theme }) => ({
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: theme.spacing(1),
+}))
+
+const StatsItem = styled.li({})
+
 const HiddenInput = styled.input({
   display: 'none',
 })
@@ -99,7 +110,7 @@ const Toolbar: React.FC<Props> = ({
   }, [])
 
   return (
-    <ToolbarContainer id="toolbar">
+    <ToolbarContainer role="toolbar" aria-label="Editor actions" id="toolbar">
       <ToolbarItemContainer>
         <Button label="New" onClick={handleNew} />
         <Button label="Open" onClick={handleOpen} />
@@ -131,15 +142,23 @@ const Toolbar: React.FC<Props> = ({
         <Label size="tiny" css={(theme) => ({ color: theme.colors.secondary })}>
           Stats
         </Label>
-        <Label size="tiny">
-          {stats.wordCount === 1 ? '1 word' : `${stats.wordCount} words`}
-        </Label>
-        <Label size="tiny">
-          {stats.characterCount === 1
-            ? '1 character'
-            : `${stats.characterCount} characters`}
-        </Label>
-        <Label size="tiny">{stats.readingTime}</Label>
+        <StatsList>
+          <StatsItem>
+            <Label size="tiny">
+              {stats.wordCount === 1 ? '1 word' : `${stats.wordCount} words`}
+            </Label>
+          </StatsItem>
+          <StatsItem>
+            <Label size="tiny">
+              {stats.characterCount === 1
+                ? '1 character'
+                : `${stats.characterCount} characters`}
+            </Label>
+          </StatsItem>
+          <StatsItem>
+            <Label size="tiny">{stats.readingTime}</Label>
+          </StatsItem>
+        </StatsList>
       </ToolbarItemContainer>
       <ToolbarItemContainer>
         <Label size="tiny" css={(theme) => ({ color: theme.colors.secondary })}>

--- a/src/menu/components/Toolbar.tsx
+++ b/src/menu/components/Toolbar.tsx
@@ -179,7 +179,16 @@ const Toolbar: React.FC<Props> = ({
           </ListItem>
         </List>
       </ToolbarItemContainer>
-      <ToolbarItemContainer as="aside" aria-label="Keyboard Shortcuts">
+      <ToolbarItemContainer
+        as="aside"
+        aria-label="Keyboard Shortcuts"
+        css={(theme) => ({
+          display: 'none',
+          [theme.breakpoints.lg]: {
+            display: 'flex',
+          },
+        })}
+      >
         <Label size="tiny" css={(theme) => ({ color: theme.colors.secondary })}>
           Keyboard Shortcuts
         </Label>

--- a/src/menu/components/Toolbar.tsx
+++ b/src/menu/components/Toolbar.tsx
@@ -40,7 +40,9 @@ const StatsList = styled.ul(({ theme }) => ({
   gap: theme.spacing(1),
 }))
 
-const StatsItem = styled.li({})
+const StatsItem = styled.li({
+  lineHeight: '1',
+})
 
 const HiddenInput = styled.input({
   display: 'none',

--- a/src/menu/components/Toolbar.tsx
+++ b/src/menu/components/Toolbar.tsx
@@ -31,7 +31,7 @@ const ToolbarItemContainer = styled.div(({ theme }) => ({
   gap: theme.spacing(1),
 }))
 
-const StatsList = styled.ul(({ theme }) => ({
+const List = styled.ul(({ theme }) => ({
   listStyle: 'none',
   margin: 0,
   padding: 0,
@@ -40,9 +40,26 @@ const StatsList = styled.ul(({ theme }) => ({
   gap: theme.spacing(1),
 }))
 
-const StatsItem = styled.li({
+const ListItem = styled.li({
   lineHeight: '1',
 })
+
+const StyledKbd = styled.kbd(({ theme }) => ({
+  backgroundColor: theme.colors.page,
+  color: theme.colors.secondary,
+  borderRadius: '0.25rem',
+  border: `1px solid ${theme.colors.shadow}`,
+  boxShadow: `0 1px 0 0.5px ${theme.colors.shadow}`,
+  fontSize: theme.fontSize.kbd,
+  lineHeight: '1',
+  minWidth: '0.75rem',
+  display: 'inline-block',
+  textAlign: 'center',
+  padding: '2px 5px',
+  position: 'relative',
+  top: '-1px',
+  transition: `background-color ${theme.animations.transition}, color ${theme.animations.transition}, border ${theme.animations.transition}, box-shadow ${theme.animations.transition}`,
+}))
 
 const HiddenInput = styled.input({
   display: 'none',
@@ -144,23 +161,42 @@ const Toolbar: React.FC<Props> = ({
         <Label size="tiny" css={(theme) => ({ color: theme.colors.secondary })}>
           Stats
         </Label>
-        <StatsList>
-          <StatsItem>
+        <List>
+          <ListItem>
             <Label size="tiny">
               {stats.wordCount === 1 ? '1 word' : `${stats.wordCount} words`}
             </Label>
-          </StatsItem>
-          <StatsItem>
+          </ListItem>
+          <ListItem>
             <Label size="tiny">
               {stats.characterCount === 1
                 ? '1 character'
                 : `${stats.characterCount} characters`}
             </Label>
-          </StatsItem>
-          <StatsItem>
+          </ListItem>
+          <ListItem>
             <Label size="tiny">{stats.readingTime}</Label>
-          </StatsItem>
-        </StatsList>
+          </ListItem>
+        </List>
+      </ToolbarItemContainer>
+      <ToolbarItemContainer as="aside" aria-label="Keyboard Shortcuts">
+        <Label size="tiny" css={(theme) => ({ color: theme.colors.secondary })}>
+          Keyboard Shortcuts
+        </Label>
+        <List>
+          <ListItem>
+            <Label size="tiny">
+              <StyledKbd>Ctrl</StyledKbd> + <StyledKbd>Shift</StyledKbd> +{' '}
+              <StyledKbd>M</StyledKbd> (Mac) / <StyledKbd>Ctrl</StyledKbd> +{' '}
+              <StyledKbd>M</StyledKbd> Toggle capture tab key in editor
+            </Label>
+          </ListItem>
+          <ListItem>
+            <Label size="tiny">
+              <StyledKbd>Esc</StyledKbd> Toggle menu
+            </Label>
+          </ListItem>
+        </List>
       </ToolbarItemContainer>
       <ToolbarItemContainer>
         <Label size="tiny" css={(theme) => ({ color: theme.colors.secondary })}>

--- a/src/menu/containers/Menu.tsx
+++ b/src/menu/containers/Menu.tsx
@@ -31,7 +31,7 @@ const Menu: React.FC = () => {
     dispatch(closeMenu())
   }, [dispatch])
 
-  useEscapeKey(handleCloseMenu)
+  useEscapeKey(handleToggleMenu)
 
   // Initially open the menu if the screen is wide enough
   useEffect(() => {

--- a/src/shared/styles.ts
+++ b/src/shared/styles.ts
@@ -1,0 +1,17 @@
+import { css, Theme } from '@emotion/react'
+
+export const focusVisibleStyles = ({ theme }: { theme: Theme }) =>
+  css({
+    '&:focus-visible': {
+      outline: `2px solid ${theme.colors.primary}`,
+      outlineOffset: '2px',
+    },
+  })
+
+export const focusWithinStyles = ({ theme }: { theme: Theme }) =>
+  css({
+    '&:focus-within': {
+      outline: `2px solid ${theme.colors.primary}`,
+      outlineOffset: '2px',
+    },
+  })

--- a/src/shared/styles.ts
+++ b/src/shared/styles.ts
@@ -5,6 +5,7 @@ export const focusVisibleStyles = ({ theme }: { theme: Theme }) =>
     '&:focus-visible': {
       outline: `2px solid ${theme.colors.primary}`,
       outlineOffset: '2px',
+      borderRadius: theme.spacing(0.25),
     },
   })
 
@@ -13,5 +14,6 @@ export const focusWithinStyles = ({ theme }: { theme: Theme }) =>
     '&:focus-within': {
       outline: `2px solid ${theme.colors.primary}`,
       outlineOffset: '2px',
+      borderRadius: theme.spacing(0.25),
     },
   })

--- a/src/theme/components/GlobalStyles.tsx
+++ b/src/theme/components/GlobalStyles.tsx
@@ -23,6 +23,17 @@ const globalStyles: CSSObject = {
     zIndex: 1000,
     position: 'relative',
   },
+  '.sr-only': {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: '0',
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    border: '0',
+  },
 }
 
 // At first we had these styles merged with "globalStyles", which caused

--- a/src/theme/components/ThemeSwitch.tsx
+++ b/src/theme/components/ThemeSwitch.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from 'react'
 import styled from '@emotion/styled'
 
 import { AppTheme } from '../themeSlice'
+
+import { focusVisibleStyles } from '../../shared/styles'
+
 import { IconButtonWrapper } from '../../app/components/IconButtonWrapper'
 import { Appear } from '../../app/components/Appear'
 import { InteractiveLabel } from '../../app/components/InteractiveLabel'
@@ -39,19 +42,22 @@ const Moon = styled(Orbiter)({
   transform: 'rotate(180deg)',
 })
 
-const StyledButtonContainer = styled.button(({ theme }) => ({
-  display: 'flex',
-  alignItems: 'center',
-  flexDirection: 'row',
-  gap: theme.spacing(1),
-  background: 'transparent',
-  border: 'none',
-  cursor: 'pointer',
-  padding: 0,
-  margin: 0,
-  width: 'fit-content',
-  height: 'fit-content',
-}))
+const StyledButtonContainer = styled.button(
+  ({ theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: theme.spacing(1),
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    padding: 0,
+    margin: 0,
+    width: 'fit-content',
+    height: 'fit-content',
+  }),
+  focusVisibleStyles,
+)
 
 export const ThemeSwitch = ({ selectedTheme, onToggleTheme, size }: Props) => {
   const [sunPosition, setSunPosition] = useState(

--- a/src/theme/selectors.ts
+++ b/src/theme/selectors.ts
@@ -78,6 +78,7 @@ export type CustomTheme = BaseTheme & {
     modal: string
     modalBackdrop: string
     punctuation: string
+    editorFocus: string
   }
   opacity: {
     disabled: number
@@ -133,6 +134,7 @@ const LIGHT_THEME: CustomTheme = {
     modal: 'rgba(255, 255, 255, 1)',
     modalBackdrop: 'rgba(255, 255, 255, 0.8)',
     punctuation: 'rgba(156, 109, 255, 0.5)',
+    editorFocus: 'rgba(156, 109, 255, 0.3)',
   },
   opacity: {
     disabled: 0.5,
@@ -156,6 +158,7 @@ const DARK_THEME: CustomTheme = {
     modal: 'rgba(44, 44, 44, 1)',
     modalBackdrop: 'rgba(34, 34, 34, 0.9)',
     punctuation: 'rgba(156, 109, 255, 0.5)',
+    editorFocus: 'rgba(156, 109, 255, 0.3)',
   },
   opacity: {
     disabled: 0.5,

--- a/src/theme/selectors.ts
+++ b/src/theme/selectors.ts
@@ -58,6 +58,7 @@ interface BaseTheme {
     small: string
     tiny: string
     editor: string
+    kbd: string
   }
 }
 
@@ -111,6 +112,7 @@ const BASE_THEME: BaseTheme = {
     small: '0.875rem',
     tiny: '0.75rem',
     editor: '1rem',
+    kbd: '0.6rem',
   },
 }
 


### PR DESCRIPTION
## Summary
- convert root layout to use `<main>` and `<nav>` landmarks
- label the menu navigation
- add toolbar semantics and structure stats as a list

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684970bac7f88326aefad3550a3beca7