### PR TITLE
#49: Envelope encryption for API key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ Here are some additional steps that can't be done in the code:
    - Add production domain to the "Authorized Domains" list
 1. Select the "Blaze" plan in the Firebase console (this is required to make requests to third party services within Cloud Functions)
 1. Make sure to set Budgets & Alerts in the Firebase console for your billing account.
+1. Set up the encryption master key for API key storage (required for Structured Todos):
+   ```bash
+   # Generate a secure 32-byte key and set it as a Firebase secret
+   firebase functions:secrets:set ENCRYPTION_MASTER_KEY
+   # When prompted, enter a secure random string (at least 32 characters)
+   ```
 
 Also, you need to create your `.firebaserc` file in the root of the project and add your project id:
 
@@ -137,6 +143,15 @@ VITE_USE_FIREBASE_EMULATOR=true bun run dev
 ```
 
 Security rules (`firestore.rules`) restrict access to a user's own docs.
+
+To test Structured Todos locally, create a `.secret.local` file in `packages/functions/` with the encryption key:
+
+```bash
+# packages/functions/.secret.local
+ENCRYPTION_MASTER_KEY=your-local-test-key-at-least-32-chars
+```
+
+This file is read by the Firebase emulator and is already in `.gitignore`.
 
 ### Using Cloud Sync
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -37,18 +37,32 @@ service cloud.firestore {
                   && request.auth.uid == userId;
 
       // Allow writes for the authenticated user with proper schema validation
+      // Note: Client can only write 'enabled', 'hasApiKey' is managed by cloud functions
       allow write: if request.auth != null
                    && request.auth.uid == userId
                    // Validate that only expected fields are present
-                   && request.resource.data.keys().hasOnly(['enabled', 'apiKey'])
+                   && request.resource.data.keys().hasOnly(['enabled', 'hasApiKey'])
                    // enabled must be a boolean
                    && request.resource.data.enabled is bool
-                   // apiKey is optional but must be a string if present
-                   && (!('apiKey' in request.resource.data) || request.resource.data.apiKey is string);
+                   // hasApiKey is optional but must be a boolean if present
+                   && (!('hasApiKey' in request.resource.data) || request.resource.data.hasApiKey is bool);
 
       // Allow deletes for the authenticated user
       allow delete: if request.auth != null
                    && request.auth.uid == userId;
+    }
+
+    // Rules for encrypted API key storage - SERVER ONLY
+    // Only Cloud Functions (Admin SDK) can access these documents
+    match /users/{userId}/secrets/{secretId} {
+      // Block ALL client reads
+      allow read: if false;
+
+      // Block ALL client writes
+      allow write: if false;
+
+      // Block ALL client deletes
+      allow delete: if false;
     }
 
     // Rules for structured todos data (synced todos + hash)

--- a/packages/app/src/settings/components/SettingsModal.tsx
+++ b/packages/app/src/settings/components/SettingsModal.tsx
@@ -344,9 +344,10 @@ export const SettingsModal: React.FC<Props> = ({
                     <MutedLabel size="tiny">
                       <strong>🔐 Security Information:</strong>
                       <br />
-                      Your API key will be stored in the cloud (Firestore) and
-                      is transmitted over encrypted connections. Access to your
-                      API key is restricted to your login credentials.
+                      Your API key is encrypted and stored securely in the
+                      cloud. It is encrypted both in transit and at rest, and
+                      can only be decrypted by the server when processing your
+                      todos.
                       <br />
                       <br />
                       <strong>⚠️ Important:</strong> Like any web application

--- a/packages/app/src/structured-todos/StructuredTodosManager.test.ts
+++ b/packages/app/src/structured-todos/StructuredTodosManager.test.ts
@@ -41,7 +41,6 @@ describe('StructuredTodosManager', () => {
     it('should save settings to Firestore', async () => {
       const settings: StructuredTodosSettings = {
         enabled: true,
-        apiKey: 'test-api-key',
       }
 
       const mockSettingsRef = { id: 'settings-ref' }
@@ -139,7 +138,7 @@ describe('StructuredTodosManager', () => {
       const mockTodosRef = { id: 'todos-ref' }
       const mockSettingsSnapshot = {
         exists: () => true,
-        data: () => ({ enabled: true, apiKey: 'test-key' }),
+        data: () => ({ enabled: true, hasApiKey: true }),
       }
 
       mockDoc
@@ -176,10 +175,22 @@ describe('StructuredTodosManager', () => {
       expect(mockOnSnapshot).toHaveBeenCalledTimes(2)
     })
 
-    it('should dispatch apiKeyIsSet false when no API key', async () => {
+    it('should dispatch apiKeyIsSet false when hasApiKey is false', async () => {
       const mockSettingsSnapshot = {
         exists: () => true,
-        data: () => ({ enabled: true }), // No apiKey
+        data: () => ({ enabled: true, hasApiKey: false }),
+      }
+      mockGetDoc.mockResolvedValue(mockSettingsSnapshot as any)
+
+      await manager.startListening(userId, mockDispatch)
+
+      expect(mockDispatch).toHaveBeenCalledWith(setApiKeyIsSet(false))
+    })
+
+    it('should dispatch apiKeyIsSet false when hasApiKey is not set', async () => {
+      const mockSettingsSnapshot = {
+        exists: () => true,
+        data: () => ({ enabled: true }), // No hasApiKey field
       }
       mockGetDoc.mockResolvedValue(mockSettingsSnapshot as any)
 

--- a/packages/app/src/structured-todos/StructuredTodosManager.ts
+++ b/packages/app/src/structured-todos/StructuredTodosManager.ts
@@ -84,9 +84,9 @@ export class StructuredTodosManager {
     const settingsSnap = await getDoc(settingsRef)
     if (settingsSnap.exists()) {
       const settings = settingsSnap.data() as StructuredTodosSettings
-      // Only sync enabled state, not API key
+      // Sync enabled state and hasApiKey flag
       dispatch(setStructuredTodosEnabled(settings.enabled))
-      dispatch(setApiKeyIsSet(!!settings.apiKey))
+      dispatch(setApiKeyIsSet(settings.hasApiKey ?? false))
     }
 
     // Then set up listener for future settings changes
@@ -96,10 +96,9 @@ export class StructuredTodosManager {
 
         log('Received structured todos settings update', settings)
 
-        // Only sync enabled state, not API key
+        // Sync enabled state and hasApiKey flag
         dispatch(setStructuredTodosEnabled(settings.enabled))
-        // Set flag to indicate if API key is set
-        dispatch(setApiKeyIsSet(!!settings.apiKey))
+        dispatch(setApiKeyIsSet(settings.hasApiKey ?? false))
       }
     })
 

--- a/packages/app/src/structured-todos/persistenceMiddleware.ts
+++ b/packages/app/src/structured-todos/persistenceMiddleware.ts
@@ -12,7 +12,12 @@ import { StructuredTodosSettings, StructuredTodosState } from './types'
 import { StructuredTodosManager } from './StructuredTodosManager'
 import { safeLocalStorage } from '../shared/storage'
 import { setCloudEnabled } from '../cloudsync/cloudSlice'
-import { processTodos, generateContentHash } from './structuredTodosService'
+import {
+  processTodos,
+  generateContentHash,
+  setApiKeyToCloud,
+  clearApiKeyFromCloud,
+} from './structuredTodosService'
 
 const STRUCTURED_TODOS_KEY = 'structuredTodos'
 const STRUCTURED_TODOS_ENABLED_KEY = `${STRUCTURED_TODOS_KEY}.enabled`
@@ -138,10 +143,10 @@ structuredTodosListenerMiddleware.startListening({
   },
 })
 
-// Listen for settings changes and sync to Firestore
+// Listen for enabled setting changes and sync to Firestore
 structuredTodosListenerMiddleware.startListening({
-  matcher: isAnyOf(setStructuredTodosEnabled, setApiKey, clearApiKey),
-  effect: async (action, listenerApi) => {
+  matcher: isAnyOf(setStructuredTodosEnabled),
+  effect: async (_action, listenerApi) => {
     const state: any = listenerApi.getState()
     const cloudUser = state.cloud?.user
 
@@ -154,16 +159,41 @@ structuredTodosListenerMiddleware.startListening({
         enabled: state.structuredTodos.enabled,
       }
 
-      // Only include API key if it's set (write-only)
-      if (state.structuredTodos.apiKey) {
-        settings.apiKey = state.structuredTodos.apiKey
-      } else if (action.type === clearApiKey.type) {
-        settings.apiKey = ''
-      }
-
       await structuredTodosManager.saveSettings(cloudUser.uid, settings)
     } catch (error) {
       console.error('Failed to sync structured todos settings:', error)
+    }
+  },
+})
+
+// Listen for API key changes and route through cloud functions
+// This ensures the key is encrypted server-side before storage
+structuredTodosListenerMiddleware.startListening({
+  matcher: isAnyOf(setApiKey, clearApiKey),
+  effect: async (action, listenerApi) => {
+    const state: any = listenerApi.getState()
+    const cloudUser = state.cloud?.user
+
+    if (!cloudUser || !state.cloud?.enabled) {
+      return
+    }
+
+    try {
+      if (action.type === setApiKey.type) {
+        const apiKey = state.structuredTodos.apiKey
+        if (apiKey) {
+          await setApiKeyToCloud(apiKey)
+        }
+      } else if (action.type === clearApiKey.type) {
+        await clearApiKeyFromCloud()
+      }
+    } catch (error) {
+      console.error('Failed to update API key:', error)
+      listenerApi.dispatch(
+        setStructuredTodosError(
+          error instanceof Error ? error.message : 'Failed to update API key',
+        ),
+      )
     }
   },
 })

--- a/packages/app/src/structured-todos/structuredTodosService.ts
+++ b/packages/app/src/structured-todos/structuredTodosService.ts
@@ -53,3 +53,64 @@ export async function generateContentHash(text: string): Promise<string> {
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
 }
+
+export interface SetApiKeyResult {
+  success: boolean
+}
+
+export interface ClearApiKeyResult {
+  success: boolean
+}
+
+/**
+ * Securely store an API key via cloud function
+ * The key is encrypted server-side before storage
+ */
+export async function setApiKeyToCloud(
+  apiKey: string,
+): Promise<SetApiKeyResult> {
+  const { app } = await getFirebase()
+  const functions = getFunctions(app, 'europe-west1')
+
+  // Connect to emulator in development if not already connected
+  if (
+    import.meta.env.VITE_USE_FIREBASE_EMULATOR === 'true' &&
+    !functionsEmulatorConnected
+  ) {
+    connectFunctionsEmulator(functions, 'localhost', 5005)
+    functionsEmulatorConnected = true
+  }
+
+  const setApiKeyFn = httpsCallable<{ apiKey: string }, SetApiKeyResult>(
+    functions,
+    'setApiKey',
+  )
+
+  const result = await setApiKeyFn({ apiKey })
+  return result.data
+}
+
+/**
+ * Clear the stored API key via cloud function
+ */
+export async function clearApiKeyFromCloud(): Promise<ClearApiKeyResult> {
+  const { app } = await getFirebase()
+  const functions = getFunctions(app, 'europe-west1')
+
+  // Connect to emulator in development if not already connected
+  if (
+    import.meta.env.VITE_USE_FIREBASE_EMULATOR === 'true' &&
+    !functionsEmulatorConnected
+  ) {
+    connectFunctionsEmulator(functions, 'localhost', 5005)
+    functionsEmulatorConnected = true
+  }
+
+  const clearApiKeyFn = httpsCallable<void, ClearApiKeyResult>(
+    functions,
+    'clearApiKey',
+  )
+
+  const result = await clearApiKeyFn()
+  return result.data
+}

--- a/packages/app/src/structured-todos/types.ts
+++ b/packages/app/src/structured-todos/types.ts
@@ -21,5 +21,5 @@ export interface StructuredTodosState {
 
 export interface StructuredTodosSettings {
   enabled: boolean
-  apiKey?: string // Optional when reading from firestore (write-only)
+  hasApiKey?: boolean // Indicates if an API key is set (key itself is stored encrypted)
 }

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -13,9 +13,31 @@ This function:
 
 - Called by the client when todo text changes (with 3s debounce)
 - Checks if structured todos are enabled for the user
-- Uses the user's OpenAI API key from Firestore settings
+- Retrieves and decrypts the user's OpenAI API key from secure storage
 - Extracts tasks with descriptions, due dates, and priorities
 - Returns structured todos and content hash to the client
+
+### `setApiKey`
+
+**Type:** HTTP Callable
+**Purpose:** Securely stores a user's OpenAI API key.
+
+This function:
+
+- Receives the plaintext API key from the client
+- Encrypts it using AES-256-GCM with a per-user derived key
+- Stores the encrypted key in `users/{userId}/secrets/apiKey` (not accessible to clients)
+- Sets `hasApiKey: true` in the user's settings
+
+### `clearApiKey`
+
+**Type:** HTTP Callable
+**Purpose:** Removes a user's stored API key.
+
+This function:
+
+- Deletes the encrypted key from `users/{userId}/secrets/apiKey`
+- Sets `hasApiKey: false` in the user's settings
 
 ## Development
 
@@ -23,6 +45,23 @@ This function:
 
 ```bash
 bun install
+```
+
+### Setting up secrets for local development
+
+The functions use Firebase secrets for sensitive configuration (e.g., `ENCRYPTION_MASTER_KEY`). For local emulator testing, create a `.secret.local` file in this directory:
+
+```bash
+# packages/functions/.secret.local
+ENCRYPTION_MASTER_KEY=your-local-test-key-at-least-32-chars
+```
+
+This file is automatically read by the Firebase emulator. **Do not commit this file** (it's already in `.gitignore`).
+
+For production, set secrets using:
+
+```bash
+firebase functions:secrets:set ENCRYPTION_MASTER_KEY
 ```
 
 ### Serving the functions for local development

--- a/packages/functions/src/encryption.test.ts
+++ b/packages/functions/src/encryption.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'bun:test'
+import { deriveUserKey, encryptApiKey, decryptApiKey } from './encryption'
+
+describe('encryption', () => {
+  const masterKey = 'test-master-key-for-encryption-purposes'
+  const userId = 'user-123-abc'
+  const apiKey = 'sk-test-api-key-12345678901234567890'
+
+  describe('deriveUserKey', () => {
+    it('should derive a 32-byte key', () => {
+      const key = deriveUserKey(masterKey, userId)
+      expect(key).toBeInstanceOf(Buffer)
+      expect(key.length).toBe(32)
+    })
+
+    it('should derive same key for same inputs', () => {
+      const key1 = deriveUserKey(masterKey, userId)
+      const key2 = deriveUserKey(masterKey, userId)
+      expect(key1.equals(key2)).toBe(true)
+    })
+
+    it('should derive different keys for different users', () => {
+      const key1 = deriveUserKey(masterKey, 'user-1')
+      const key2 = deriveUserKey(masterKey, 'user-2')
+      expect(key1.equals(key2)).toBe(false)
+    })
+
+    it('should derive different keys for different master keys', () => {
+      const key1 = deriveUserKey('master-key-1', userId)
+      const key2 = deriveUserKey('master-key-2', userId)
+      expect(key1.equals(key2)).toBe(false)
+    })
+  })
+
+  describe('encryptApiKey', () => {
+    it('should return encrypted data with all required fields', () => {
+      const result = encryptApiKey(apiKey, masterKey, userId)
+
+      expect(result).toHaveProperty('encrypted')
+      expect(result).toHaveProperty('iv')
+      expect(result).toHaveProperty('authTag')
+      expect(result).toHaveProperty('version')
+
+      expect(typeof result.encrypted).toBe('string')
+      expect(typeof result.iv).toBe('string')
+      expect(typeof result.authTag).toBe('string')
+      expect(result.version).toBe(1)
+    })
+
+    it('should produce different ciphertext each time (due to random IV)', () => {
+      const result1 = encryptApiKey(apiKey, masterKey, userId)
+      const result2 = encryptApiKey(apiKey, masterKey, userId)
+
+      expect(result1.encrypted).not.toBe(result2.encrypted)
+      expect(result1.iv).not.toBe(result2.iv)
+    })
+
+    it('should produce valid base64 encoded strings', () => {
+      const result = encryptApiKey(apiKey, masterKey, userId)
+
+      // Should not throw when decoding base64
+      expect(() => Buffer.from(result.encrypted, 'base64')).not.toThrow()
+      expect(() => Buffer.from(result.iv, 'base64')).not.toThrow()
+      expect(() => Buffer.from(result.authTag, 'base64')).not.toThrow()
+    })
+
+    it('should produce a 12-byte IV (96 bits)', () => {
+      const result = encryptApiKey(apiKey, masterKey, userId)
+      const iv = Buffer.from(result.iv, 'base64')
+      expect(iv.length).toBe(12)
+    })
+
+    it('should produce a 16-byte auth tag (128 bits)', () => {
+      const result = encryptApiKey(apiKey, masterKey, userId)
+      const authTag = Buffer.from(result.authTag, 'base64')
+      expect(authTag.length).toBe(16)
+    })
+  })
+
+  describe('decryptApiKey', () => {
+    it('should decrypt to the original plaintext', () => {
+      const encrypted = encryptApiKey(apiKey, masterKey, userId)
+      const decrypted = decryptApiKey(encrypted, masterKey, userId)
+
+      expect(decrypted).toBe(apiKey)
+    })
+
+    it('should handle empty strings', () => {
+      const encrypted = encryptApiKey('', masterKey, userId)
+      const decrypted = decryptApiKey(encrypted, masterKey, userId)
+
+      expect(decrypted).toBe('')
+    })
+
+    it('should handle long API keys', () => {
+      const longApiKey = 'sk-' + 'a'.repeat(1000)
+      const encrypted = encryptApiKey(longApiKey, masterKey, userId)
+      const decrypted = decryptApiKey(encrypted, masterKey, userId)
+
+      expect(decrypted).toBe(longApiKey)
+    })
+
+    it('should handle special characters', () => {
+      const specialApiKey = 'sk-test_key.with/special+chars=123!@#$%'
+      const encrypted = encryptApiKey(specialApiKey, masterKey, userId)
+      const decrypted = decryptApiKey(encrypted, masterKey, userId)
+
+      expect(decrypted).toBe(specialApiKey)
+    })
+
+    it('should fail with wrong master key', () => {
+      const encrypted = encryptApiKey(apiKey, masterKey, userId)
+
+      expect(() =>
+        decryptApiKey(encrypted, 'wrong-master-key', userId),
+      ).toThrow()
+    })
+
+    it('should fail with wrong userId', () => {
+      const encrypted = encryptApiKey(apiKey, masterKey, userId)
+
+      expect(() =>
+        decryptApiKey(encrypted, masterKey, 'wrong-user-id'),
+      ).toThrow()
+    })
+
+    it('should fail with tampered ciphertext', () => {
+      const encrypted = encryptApiKey(apiKey, masterKey, userId)
+      const tamperedEncrypted = {
+        ...encrypted,
+        encrypted: 'tampered' + encrypted.encrypted.slice(8),
+      }
+
+      expect(() =>
+        decryptApiKey(tamperedEncrypted, masterKey, userId),
+      ).toThrow()
+    })
+
+    it('should fail with tampered auth tag', () => {
+      const encrypted = encryptApiKey(apiKey, masterKey, userId)
+      const tamperedEncrypted = {
+        ...encrypted,
+        authTag: Buffer.from('0'.repeat(16)).toString('base64'),
+      }
+
+      expect(() =>
+        decryptApiKey(tamperedEncrypted, masterKey, userId),
+      ).toThrow()
+    })
+
+    it('should fail with tampered IV', () => {
+      const encrypted = encryptApiKey(apiKey, masterKey, userId)
+      const tamperedEncrypted = {
+        ...encrypted,
+        iv: Buffer.from('0'.repeat(12)).toString('base64'),
+      }
+
+      expect(() =>
+        decryptApiKey(tamperedEncrypted, masterKey, userId),
+      ).toThrow()
+    })
+  })
+
+  describe('roundtrip', () => {
+    it('should handle multiple encrypt/decrypt cycles', () => {
+      for (let i = 0; i < 10; i++) {
+        const testKey = `sk-test-key-${i}-${Date.now()}`
+        const encrypted = encryptApiKey(testKey, masterKey, userId)
+        const decrypted = decryptApiKey(encrypted, masterKey, userId)
+        expect(decrypted).toBe(testKey)
+      }
+    })
+
+    it('should work with different users', () => {
+      const users = ['user-1', 'user-2', 'user-3']
+
+      for (const user of users) {
+        const encrypted = encryptApiKey(apiKey, masterKey, user)
+        const decrypted = decryptApiKey(encrypted, masterKey, user)
+        expect(decrypted).toBe(apiKey)
+      }
+    })
+  })
+})

--- a/packages/functions/src/encryption.ts
+++ b/packages/functions/src/encryption.ts
@@ -1,0 +1,114 @@
+/**
+ * Encryption utilities for API key storage
+ *
+ * Uses envelope encryption with:
+ * - HKDF for per-user key derivation from master key
+ * - AES-256-GCM for authenticated encryption
+ */
+
+import * as crypto from 'crypto'
+
+const ALGORITHM = 'aes-256-gcm'
+const IV_LENGTH = 12 // 96 bits recommended for GCM
+const AUTH_TAG_LENGTH = 16 // 128 bits
+const KEY_LENGTH = 32 // 256 bits for AES-256
+
+export interface EncryptedData {
+  encrypted: string // base64 encoded ciphertext
+  iv: string // base64 encoded IV
+  authTag: string // base64 encoded authentication tag
+  version: number // key version for future rotation support
+}
+
+/**
+ * Derives a unique encryption key for a user from the master key using HKDF
+ *
+ * @param masterKey - The master encryption key (from Firebase secrets)
+ * @param userId - The user's Firebase UID
+ * @returns A 32-byte derived key unique to this user
+ */
+export function deriveUserKey(masterKey: string, userId: string): Buffer {
+  // Use HKDF (HMAC-based Key Derivation Function)
+  // - Salt: userId (ensures unique keys per user)
+  // - Info: application-specific context string
+  const derivedKey = crypto.hkdfSync(
+    'sha256',
+    Buffer.from(masterKey, 'utf8'),
+    Buffer.from(userId, 'utf8'), // salt
+    'doppelpunkt-api-key-encryption', // info
+    KEY_LENGTH,
+  )
+  // hkdfSync returns ArrayBuffer in Bun, convert to Buffer
+  return Buffer.from(derivedKey)
+}
+
+/**
+ * Encrypts an API key using AES-256-GCM with a user-derived key
+ *
+ * @param apiKey - The plaintext API key to encrypt
+ * @param masterKey - The master encryption key
+ * @param userId - The user's Firebase UID
+ * @returns Encrypted data with IV and auth tag
+ */
+export function encryptApiKey(
+  apiKey: string,
+  masterKey: string,
+  userId: string,
+): EncryptedData {
+  const userKey = deriveUserKey(masterKey, userId)
+  const iv = crypto.randomBytes(IV_LENGTH)
+
+  const cipher = crypto.createCipheriv(ALGORITHM, userKey, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  })
+
+  // Use userId as additional authenticated data (AAD)
+  // This binds the ciphertext to this specific user
+  cipher.setAAD(Buffer.from(userId, 'utf8'))
+
+  let encrypted = cipher.update(apiKey, 'utf8', 'base64')
+  encrypted += cipher.final('base64')
+
+  const authTag = cipher.getAuthTag()
+
+  return {
+    encrypted,
+    iv: iv.toString('base64'),
+    authTag: authTag.toString('base64'),
+    version: 1, // Current key version
+  }
+}
+
+/**
+ * Decrypts an API key using AES-256-GCM with a user-derived key
+ *
+ * @param encryptedData - The encrypted data object
+ * @param masterKey - The master encryption key
+ * @param userId - The user's Firebase UID
+ * @returns The decrypted API key
+ * @throws Error if decryption fails (wrong key, tampered data, etc.)
+ */
+export function decryptApiKey(
+  encryptedData: EncryptedData,
+  masterKey: string,
+  userId: string,
+): string {
+  const userKey = deriveUserKey(masterKey, userId)
+  const iv = Buffer.from(encryptedData.iv, 'base64')
+  const authTag = Buffer.from(encryptedData.authTag, 'base64')
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, userKey, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  })
+
+  decipher.setAuthTag(authTag)
+
+  // Use userId as additional authenticated data (AAD)
+  // Must match the AAD used during encryption
+  decipher.setAAD(Buffer.from(userId, 'utf8'))
+
+  let decrypted = decipher.update(encryptedData.encrypted, 'base64', 'utf8')
+  decrypted += decipher.final('utf8')
+
+  return decrypted
+}

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -3,11 +3,16 @@
  */
 
 import { onCall, HttpsError } from 'firebase-functions/v2/https'
+import { defineSecret } from 'firebase-functions/params'
 import { initializeApp } from 'firebase-admin/app'
-import { getFirestore } from 'firebase-admin/firestore'
+import { getFirestore, FieldValue } from 'firebase-admin/firestore'
 import { logger } from 'firebase-functions'
 import { StructuredTodosProcessor } from './structuredTodosProcessor'
 import { StructuredTodosSettings } from './types'
+import { encryptApiKey, decryptApiKey, EncryptedData } from './encryption'
+
+// Define the master encryption key secret
+const ENCRYPTION_MASTER_KEY = defineSecret('ENCRYPTION_MASTER_KEY')
 
 // Initialize Firebase Admin
 initializeApp()
@@ -36,6 +41,7 @@ export const processTodos = onCall<ProcessTodosRequest>(
   {
     region: 'europe-west1',
     maxInstances: 10,
+    secrets: [ENCRYPTION_MASTER_KEY],
   },
   async (request): Promise<ProcessTodosResponse> => {
     const userId = request.auth?.uid
@@ -54,7 +60,7 @@ export const processTodos = onCall<ProcessTodosRequest>(
     }
 
     try {
-      // Get user's structured todos settings (for API key)
+      // Get user's structured todos settings
       const settingsRef = db.doc(`users/${userId}/settings/structuredTodos`)
       const settingsSnap = await settingsRef.get()
 
@@ -74,10 +80,21 @@ export const processTodos = onCall<ProcessTodosRequest>(
         )
       }
 
-      if (!settings.apiKey) {
+      // Check if API key is set (fast check before decryption)
+      if (!settings.hasApiKey) {
         throw new HttpsError(
           'failed-precondition',
           'OpenAI API key not configured',
+        )
+      }
+
+      // Get and decrypt the API key
+      const apiKey = await getDecryptedApiKey(userId)
+
+      if (!apiKey) {
+        throw new HttpsError(
+          'failed-precondition',
+          'API key not found or could not be decrypted',
         )
       }
 
@@ -86,7 +103,7 @@ export const processTodos = onCall<ProcessTodosRequest>(
 
       // Process the todo text
       logger.info(`Processing todos for user ${userId}`)
-      const processor = new StructuredTodosProcessor(settings.apiKey)
+      const processor = new StructuredTodosProcessor(apiKey)
       const todos = await processor.extractTodos(todoText)
 
       logger.info(
@@ -122,4 +139,165 @@ async function generateContentHash(text: string): Promise<string> {
   const hashBuffer = await crypto.subtle.digest('SHA-256', data)
   const hashArray = Array.from(new Uint8Array(hashBuffer))
   return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+// Request/Response types for API key management
+export interface SetApiKeyRequest {
+  apiKey: string
+}
+
+export interface SetApiKeyResponse {
+  success: boolean
+}
+
+export interface ClearApiKeyResponse {
+  success: boolean
+}
+
+/**
+ * Callable function to securely store an API key
+ * Encrypts the key using envelope encryption before storing in Firestore
+ */
+export const setApiKey = onCall<SetApiKeyRequest>(
+  {
+    region: 'europe-west1',
+    secrets: [ENCRYPTION_MASTER_KEY],
+  },
+  async (request): Promise<SetApiKeyResponse> => {
+    const userId = request.auth?.uid
+
+    if (!userId) {
+      throw new HttpsError(
+        'unauthenticated',
+        'Must be signed in to set API key',
+      )
+    }
+
+    const { apiKey } = request.data
+
+    if (!apiKey || typeof apiKey !== 'string') {
+      throw new HttpsError(
+        'invalid-argument',
+        'apiKey must be a non-empty string',
+      )
+    }
+
+    // Basic validation - OpenAI keys start with 'sk-'
+    if (!apiKey.startsWith('sk-')) {
+      throw new HttpsError(
+        'invalid-argument',
+        'Invalid API key format. OpenAI keys start with sk-',
+      )
+    }
+
+    try {
+      const masterKey = ENCRYPTION_MASTER_KEY.value()
+
+      if (!masterKey) {
+        logger.error('ENCRYPTION_MASTER_KEY not configured')
+        throw new HttpsError('internal', 'Encryption not configured')
+      }
+
+      // Encrypt the API key
+      const encryptedData = encryptApiKey(apiKey, masterKey, userId)
+
+      // Store encrypted key in secrets path (not accessible to clients)
+      const secretsRef = db.doc(`users/${userId}/secrets/apiKey`)
+      await secretsRef.set({
+        ...encryptedData,
+        updatedAt: FieldValue.serverTimestamp(),
+      })
+
+      // Update settings to indicate key is set
+      const settingsRef = db.doc(`users/${userId}/settings/structuredTodos`)
+      await settingsRef.set({ hasApiKey: true }, { merge: true })
+
+      logger.info(`API key stored for user ${userId}`)
+
+      return { success: true }
+    } catch (error) {
+      logger.error(`Error setting API key for user ${userId}:`, error)
+
+      if (error instanceof HttpsError) {
+        throw error
+      }
+
+      throw new HttpsError(
+        'internal',
+        error instanceof Error ? error.message : 'Failed to store API key',
+      )
+    }
+  },
+)
+
+/**
+ * Callable function to clear the stored API key
+ */
+export const clearApiKey = onCall(
+  {
+    region: 'europe-west1',
+  },
+  async (request): Promise<ClearApiKeyResponse> => {
+    const userId = request.auth?.uid
+
+    if (!userId) {
+      throw new HttpsError(
+        'unauthenticated',
+        'Must be signed in to clear API key',
+      )
+    }
+
+    try {
+      // Delete the encrypted key
+      const secretsRef = db.doc(`users/${userId}/secrets/apiKey`)
+      await secretsRef.delete()
+
+      // Update settings to indicate key is no longer set
+      const settingsRef = db.doc(`users/${userId}/settings/structuredTodos`)
+      await settingsRef.set({ hasApiKey: false }, { merge: true })
+
+      logger.info(`API key cleared for user ${userId}`)
+
+      return { success: true }
+    } catch (error) {
+      logger.error(`Error clearing API key for user ${userId}:`, error)
+
+      if (error instanceof HttpsError) {
+        throw error
+      }
+
+      throw new HttpsError(
+        'internal',
+        error instanceof Error ? error.message : 'Failed to clear API key',
+      )
+    }
+  },
+)
+
+/**
+ * Helper function to retrieve and decrypt an API key for server-side use
+ */
+async function getDecryptedApiKey(userId: string): Promise<string | null> {
+  const masterKey = ENCRYPTION_MASTER_KEY.value()
+
+  if (!masterKey) {
+    logger.error('ENCRYPTION_MASTER_KEY not configured')
+    return null
+  }
+
+  const secretsRef = db.doc(`users/${userId}/secrets/apiKey`)
+  const secretsSnap = await secretsRef.get()
+
+  if (!secretsSnap.exists) {
+    return null
+  }
+
+  const encryptedData = secretsSnap.data() as EncryptedData
+
+  try {
+    return decryptApiKey(encryptedData, masterKey, userId)
+  } catch (error) {
+    logger.error(`Failed to decrypt API key for user ${userId}:`, error)
+    return null
+  }
 }

--- a/packages/functions/src/types.ts
+++ b/packages/functions/src/types.ts
@@ -10,5 +10,5 @@ export interface StructuredTodo {
 
 export interface StructuredTodosSettings {
   enabled: boolean
-  apiKey?: string
+  hasApiKey?: boolean
 }


### PR DESCRIPTION
Closes #49 

## Summary
- API keys are now encrypted at rest using AES-256-GCM with per-user derived keys
- Client can no longer read API keys from Firestore (server-only access)
- New `setApiKey` and `clearApiKey` cloud functions handle secure storage

## Test plan
- [x] Set API key via settings UI
- [x] Verify encrypted data in Firestore `/secrets/` path
- [x] Verify `hasApiKey` flag is set in settings
- [x] Clear API key and verify removal
- [x] Process todos with encrypted key
- [x] All tests pass