### PR TITLE
#51: Fix undo/redo mixing content between editor and todo modes

### DIFF
--- a/packages/app/src/editor/containers/MarkdownEditor.tsx
+++ b/packages/app/src/editor/containers/MarkdownEditor.tsx
@@ -222,6 +222,9 @@ const MarkdownEditor: React.FC = () => {
 
   return (
     <MarkdownEditorComponent
+      // Reset browser undo/redo stack when switching modes to prevent
+      // cross-mode content mixing (see issue #51)
+      key={mode}
       content={injectedValue}
       onContentChange={handleContentChange}
       captureTab={captureTab}


### PR DESCRIPTION
Add key prop to MarkdownEditorComponent based on current writing mode.
This forces React to remount the editor when switching modes, which
resets the browser's native undo/redo stack and prevents cross-mode
content mixing.

Closes #51 